### PR TITLE
Fix teaser block overwrite default behavior

### DIFF
--- a/src/blocks.json
+++ b/src/blocks.json
@@ -25,7 +25,7 @@
         },
         "overwrite": {
           "type": "boolean",
-          "description": "Set to true only if using custom values instead of the target object's properties. It must be set to fale is only 'href' is provided."
+          "description": "Set to true only if using custom values instead of the target object's properties. When only 'href' is provided, omit this field or set it to false so the teaser will fetch the live target properties."
         },
         "title": {
           "type": "string",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1472,23 +1472,26 @@ class PloneMCPServer {
       teaser: {
         href: [
           {
-            "@id": "https://example.com/news/latest-updates",
-          },
+            "@id": "https://example.com/news/latest-updates"
+          }
         ],
-        overwrite: true,
+        // Do NOT set `overwrite` by default in examples. `overwrite` should only
+        // be present when the caller intentionally overrides the target object's
+        // properties (title, description, preview_image). Omitting `overwrite`
+        // makes the teaser fetch live data from the target by default.
         title: "Latest Company Updates",
         head_title: "News",
         description: "Read about our recent achievements and announcements",
         preview_image: [
           {
             "@id": "https://example.com/images/latest-updates-preview.jpg",
-            image_field: "image",
-          },
+            image_field: "image"
+          }
         ],
         theme: "default",
         styles: {
-          align: "left",
-        },
+          align: "left"
+        }
       },
       slate: {
         text: "This is a paragraph of text content that will be converted to Slate format.",


### PR DESCRIPTION
This PR addresses issue #11 by fixing the teaser block's default behavior regarding the `overwrite` property.

## Changes Made

- **Removed `overwrite: true` from teaser example**: The example in `getBlockExample()` no longer sets `overwrite: true` by default, preventing users from copying this as a standard pattern.

- **Fixed typo in blocks.json**: Corrected the description of the `overwrite` property and clarified that it should be omitted or set to false to fetch live target properties.

- **Added clarifying comment**: Added documentation in the example explaining when and why to use `overwrite`.

## Problem Solved

The issue was that teaser blocks were being created with `overwrite: true` by default, which prevented them from fetching live data from the target content. This meant:
- Teasers wouldn't automatically update when target content changed
- Links might not work properly if the overwrite data was incomplete
- Users had to manually manage teaser content instead of leveraging Plone's automatic content resolution

## Verification

- All existing unit tests pass
- Build completes successfully
- Changes maintain backward compatibility

Closes #11