### PR TITLE
Add llm instructions to teaser specs

### DIFF
--- a/src/blocks.json
+++ b/src/blocks.json
@@ -1,6 +1,16 @@
 {
   "teaser": {
     "description": "The teaser block is used to create a teaser for a content item. It links to a target and displays its properties (title, description, preview image, etc.). In most cases, only 'href' should be provided - the teaser will automatically use the target's properties. To customize the display, set 'overwrite: true' and provide custom values.",
+    "llm_instructions": {
+      "priority": "CRITICAL",
+      "required_clarifications": [
+        {
+          "condition": "href is missing, or not provided by user",
+          "blocking": true,
+          "action": "STOP. Do NOT proceed without asking the user: Which content item should this teaser link to? The teaser will be blank without a target."
+        }
+      ]
+    },
     "inputSchema": {
       "blockData": {
         "href": {

--- a/src/blocks.json
+++ b/src/blocks.json
@@ -7,7 +7,7 @@
         {
           "condition": "href is missing, or not provided by user",
           "blocking": true,
-          "action": "STOP. Do NOT proceed without asking the user: Which content item should this teaser link to? The teaser will be blank without a target."
+          "action": "STOP. Do NOT proceed without asking the user: Which content item should this teaser link to? If href is not already provided. DO NOT infer, assume or use the current page URL . The teaser will be blank without an explicit target."
         }
       ]
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -618,7 +618,7 @@ class PloneMCPServer {
       {
         title: "Get Block Schemas",
         description:
-          "Lists all available Volto block types (e.g., 'slate', 'teaser', 'button') and their required data schemas. If no block type specified, the tool returns all blocks schemas. **Essential for understanding how to construct blocks.** Example: plone_get_block_schemas({blockType: 'teaser'})",
+          "Lists all available Volto block types (e.g., 'slate', 'teaser', 'button') and their required data schemas. If no block type specified, the tool returns all blocks schemas at once. **Essential for understanding how to construct blocks.** Example: plone_get_block_schemas({blockType: 'teaser'})",
         inputSchema: PloneGetBlockSchemasSchema.shape,
       },
       async (args) => this.handleGetBlockSchemas(args)


### PR DESCRIPTION
This change introduces the `llm_instructions` field to the Teaser block specification. This approach helps address ambiguity in user prompts when creating Teasers and prevents blank Teasers from being added through structured instructions. The same field can be extended to other blocks that require special handling.

**The problem**

With an ambiguous prompt like:

> Create a Teaser block

The LLM, due to its task-completion prioritization, would typically improvise an `href` (often defaulting to the portal root or the current page), which is rarely the intended behavior and results in unhelpful or broken teasers.

**Solution** 

With this disambiguation approach, by adding `llm_instructions` to the block schema, the LLM is guided to clarify requirements with the user before proceeding:

```json
"llm_instructions": {
  "priority": "CRITICAL",
  "required_clarifications": [
    {
      "condition": "href is missing, or not provided by user",
      "blocking": true,
      "action": "STOP. Do NOT proceed without asking the user: Which content item should this teaser link to? The teaser will be blank without a target."
    }
  ]
}
```
**Example Behavior**

Before: LLM creates a teaser with an arbitrary or useless href.

After: LLM prompts the user for clarification:

> I see that a teaser block requires a target link (href) — it needs to know which content item to link to and display information from. Which content item should this teaser link to? For example:
> 
> - Should it link to an existing page on the site?
> - Would you like me to search for available content to choose from?
