### PR TITLE
Use make targets in the README development instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,16 @@ start: ## Start the MCP HTTP server from dist/ (run `make build` first)
 	echo "$(GREEN)==> Starting the MCP HTTP server$(RESET)"
 	pnpm start
 
+.PHONY: stdio
+stdio: ## Start the MCP STDIO server from dist/ (run `make build` first)
+	echo "$(GREEN)==> Starting the MCP STDIO server$(RESET)"
+	pnpm run stdio
+
+.PHONY: inspector
+inspector: ## Debug the STDIO server with the MCP Inspector (run `make build` first)
+	echo "$(GREEN)==> Starting the MCP Inspector$(RESET)"
+	npx @modelcontextprotocol/inspector node dist/stdio-server.js
+
 .PHONY: format
 format: ## Format the codebase, fixing every auto-fixable lint problem
 	echo "$(GREEN)==> Formatting the codebase$(RESET)"
@@ -74,6 +84,11 @@ type-check: ## Type-check the sources and the tests without emitting output
 test: ## Run the unit tests
 	echo "$(GREEN)==> Running the unit tests$(RESET)"
 	pnpm run test:unit
+
+.PHONY: test-all
+test-all: ## Run the whole test suite (unit and integration)
+	echo "$(GREEN)==> Running the whole test suite$(RESET)"
+	pnpm test
 
 .PHONY: test-integration
 test-integration: ## Run the integration tests

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Now ask Claude to connect to your Plone site, e.g. *"Connect to https://demo.plo
 The server ships two entry points:
 
 - **STDIO** (`plone-mcp` bin / `dist/stdio-server.js`) - for local MCP clients such as Claude Desktop.
-- **HTTP** (`dist/http-server.js`) - a streamable-HTTP server with per-session state, listening on `PORT` (default `3001`) at `/mcp`. Start it with `pnpm start`.
+- **HTTP** (`dist/http-server.js`) - a streamable-HTTP server with per-session state, listening on `PORT` (default `3001`) at `/mcp`. Start it with `make start`.
 
 ## Quick Start using Claude Desktop as an example
 
@@ -112,8 +112,8 @@ Clone the repo if you want to modify the server, debug it, or run it with the MC
 ```bash
 git clone https://github.com/plone/plone-mcp.git
 cd plone-mcp
-pnpm install
-pnpm run build
+make install
+make build
 ```
 
 Point Claude Desktop at your local build instead of the `npx` command:
@@ -132,31 +132,31 @@ Point Claude Desktop at your local build instead of the `npx` command:
 Development commands:
 
 ```bash
-# Development mode with hot reload
-pnpm run dev
+# Install the dependencies
+make install
 
 # Build for production (compiles TypeScript and copies blocks.json)
-pnpm run build
+make build
 
 # Run the HTTP server / the STDIO server from the build
-pnpm start
-pnpm run stdio
+make start
+make stdio
 
-# Test with MCP Inspector
-pnpm run inspector
+# Debug with the MCP Inspector
+make inspector
 
 # Tests (Vitest)
-pnpm test              # everything
-pnpm run test:unit     # unit tests only
-pnpm run test:coverage # with coverage
+make test-all       # everything
+make test           # unit tests only
+make test-coverage  # with coverage
 
 # Static checks
-pnpm run lint          # ESLint over src/ and __tests__/
-pnpm run type-check    # tsc over sources and tests
-
-# Test with MCP Inspector
-npx @modelcontextprotocol/inspector node dist/stdio-server.js
+make lint           # ESLint over src/ and __tests__/
+make format         # ESLint with --fix
+make type-check     # tsc over sources and tests
 ```
+
+Run `make help` to list every available target.
 
 ## Core Features
 
@@ -304,7 +304,7 @@ plone_search({
 | "Block not found"                    | Use `plone_get_content` to get valid block IDs                                                                                     |
 | Connection errors                    | Verify Plone URL and credentials are correct                                                                                       |
 | Blocks not applied                   | Call `plone_create_blocks_layout` immediately before create/update (60s TTL)                                                       |
-| TypeScript errors during local build | Run `pnpm install` to ensure all dependencies are installed                                                                        |
+| TypeScript errors during local build | Run `make install` to ensure all dependencies are installed                                                                        |
 
 ## Resources
 

--- a/news/+make-targets.documentation
+++ b/news/+make-targets.documentation
@@ -1,0 +1,1 @@
+Document the local development workflow with the `make` targets instead of the raw `pnpm` commands, and add the missing `stdio`, `inspector` and `test-all` targets to the Makefile. @ericof


### PR DESCRIPTION
## What

Replaces the raw `pnpm` commands documented in the README with their `make` equivalents, and adds the targets that were missing from the Makefile to make that possible.

## Changes

**README**

- The HTTP transport is started with `make start`.
- The local development clone block uses `make install` / `make build`.
- The development commands block is fully converted to `make`, and now points at `make help` for the complete target list.
- The troubleshooting entry for a failing local build points at `make install`.

**Makefile** — three new targets:

| Target | Runs |
| --- | --- |
| `stdio` | `pnpm run stdio` — the STDIO server from `dist/` |
| `inspector` | `npx @modelcontextprotocol/inspector node dist/stdio-server.js` |
| `test-all` | `pnpm test` — the whole suite; `make test` stays unit-only |

## Note on two dropped commands

The README documented `pnpm run dev` ("development mode with hot reload") and `pnpm run inspector`. Neither script exists in `package.json`, so both lines were stale. They are dropped rather than wrapped in a target:

- `make inspector` uses the raw `npx` invocation the README already documented further down, so no capability is lost.
- There is no hot-reload equivalent. If we want one, it needs a real script (e.g. `tsx watch src/stdio-server.ts`) — happy to add it in a follow-up.

## Verification

- `make help` lists every target.
- `make test-all` → 186 tests passing across 31 files.

The one remaining `pnpm` mention in the README is prose explaining that the package manager is only needed for local development — not a command, so it stays.